### PR TITLE
Introduce primary loader.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+- Introduce primary loader through `#define_primary_loader`.
+- Deprecate `#bulk_load_and_compute` in favor of `#bulk_list_and_compute`.
+
 ## 0.1.1
 
 - Expand docs.


### PR DESCRIPTION
Our intended use-case basically treats a certain attribute special; we call it the primary (loaded) attribute. Previously ComputedModel itself didn't distinguish the primary attribute from other attributes, but it led to the following inconveniences:

- Boilerplate in loading wrapper.
- Inability to list models using non-primary-key constraints, such as listing `User`s by `group_id`s.

To resolve this, we introduce `define_primary_loader` and recommend users to define exactly one primary attribute.