### PR TITLE
Make define_loader more concise interface like GraphQL's DataLoader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Unreleased
-
+- **BREAKING CHANGE** Introduce GraphQL's DataLoader-like interface.
 - Introduce primary loader through `#define_primary_loader`.
 - Deprecate `#bulk_load_and_compute` in favor of `#bulk_list_and_compute`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Unreleased
-- **BREAKING CHANGE** Introduce GraphQL's DataLoader-like interface.
+- **BREAKING CHANGE** Make define_loader more concise interface like GraphQL's DataLoader.
 - Introduce primary loader through `#define_primary_loader`.
 - Deprecate `#bulk_load_and_compute` in favor of `#bulk_list_and_compute`.
 

--- a/README.md
+++ b/README.md
@@ -65,8 +65,7 @@ end
 
 # Example: pulling auxiliary data from ActiveRecord
 define_loader :user_aux_data, key: -> { id } do |user_ids, subdeps, **options|
-  user_aux_data = UserAuxData.where(user_id: user_ids).preload(subdeps).group_by(&:id)
-  user_ids.map { |id| user_aux_data[id] }
+  UserAuxData.where(user_id: user_ids).preload(subdeps).group_by(&:id)
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ define_primary_loader :raw_user do |subdeps, ids:, **options|
 end
 
 # Example: pulling auxiliary data from ActiveRecord
-define_loader :user_aux_data, key: -> { id } do |keys, subdeps, **options|
+define_loader :user_aux_data, key: -> { id } do |user_ids, subdeps, **options|
   user_aux_data = UserAuxData.where(user_id: user_ids).preload(subdeps).group_by(&:id)
-  keys.map { |id| user_aux_data[id] }
+  user_ids.map { |id| user_aux_data[id] }
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -64,12 +64,9 @@ define_primary_loader :raw_user do |subdeps, ids:, **options|
 end
 
 # Example: pulling auxiliary data from ActiveRecord
-define_loader :user_aux_data do |users, subdeps, **options|
-  user_ids = users.map(&:id)
+define_loader :user_aux_data, key: -> { id } do |keys, subdeps, **options|
   user_aux_data = UserAuxData.where(user_id: user_ids).preload(subdeps).group_by(&:id)
-  users.each do |user|
-    user.user_aux_data = user_aux_data[user.id]
-  end
+  keys.map { |id| user_aux_data[id] }
 end
 ```
 

--- a/lib/computed_model.rb
+++ b/lib/computed_model.rb
@@ -27,7 +27,7 @@ module ComputedModel
   # A return value from {ComputedModel::ClassMethods#computing_plan}.
   Plan = Struct.new(:load_order, :subdeps_hash)
 
-  # A object for storing procs for loaded attributes.
+  # An object for storing procs for loaded attributes.
   Loader = Struct.new(:key_proc, :load_proc)
 
   # A set of class methods for {ComputedModel}. Automatically included to the

--- a/lib/computed_model.rb
+++ b/lib/computed_model.rb
@@ -30,6 +30,8 @@ module ComputedModel
   # An object for storing procs for loaded attributes.
   Loader = Struct.new(:key_proc, :load_proc)
 
+  private_constant :Loader
+
   # A set of class methods for {ComputedModel}. Automatically included to the
   # singleton class when you include {ComputedModel}.
   module ClassMethods

--- a/lib/computed_model.rb
+++ b/lib/computed_model.rb
@@ -242,8 +242,8 @@ module ComputedModel
           l = @__computed_model_loaders[dep_name]
           keys = objs.map { |o| o.instance_exec(&(l.key_proc)) }
           subobj_by_key = l.load_proc.call(keys, plan.subdeps_hash[dep_name], **options)
-          objs.each.with_index do |obj, i|
-            obj.send(:"#{dep_name}=", subobj_by_key[keys[i]])
+          objs.zip(keys) do |obj, key|
+            obj.send(:"#{dep_name}=", subobj_by_key[key])
           end
         elsif @__computed_model_primary_attribute == dep_name
           raise "bulk_load_and_compute cannot handle a primary loader."
@@ -283,8 +283,8 @@ module ComputedModel
           l = @__computed_model_loaders[dep_name]
           keys = objs.map { |o| o.instance_exec(&(l.key_proc)) }
           subobj_by_key = l.load_proc.call(keys, plan.subdeps_hash[dep_name], **options)
-          objs.each.with_index do |obj, i|
-            obj.send(:"#{dep_name}=", subobj_by_key[keys[i]])
+          objs.zip(keys) do |obj, key|
+            obj.send(:"#{dep_name}=", subobj_by_key[key])
           end
         else
           raise "No dependency info for #{self}##{dep_name}"

--- a/spec/computed_model_spec.rb
+++ b/spec/computed_model_spec.rb
@@ -22,6 +22,30 @@ RSpec.describe ComputedModel do
       ].map { |user| [user.id, user] }.to_h
     end
 
+    class Book
+      attr_accessor :id
+      attr_accessor :author_id
+      attr_accessor :title
+
+      def initialize(id:, author_id:, title:)
+        @id = id
+        @author_id = author_id
+        @title = title
+      end
+
+      def self.list(user_ids:)
+        id_set = user_ids.to_set
+        BOOKS.select { |b| id_set.include? b.author_id }
+      end
+
+      BOOKS = [
+        Book.new(id: 1, author_id: 2, title: 'Bool One'),
+        Book.new(id: 2, author_id: 4, title: 'Bool Two'),
+        Book.new(id: 3, author_id: 2, title: 'Bool Three'),
+        Book.new(id: 4, author_id: 2, title: 'Bool Four'),
+      ].freeze
+    end
+
     class User
       include ComputedModel
 
@@ -40,11 +64,21 @@ RSpec.describe ComputedModel do
         RawUser.list(ids).map { |raw_user| User.new(raw_user) }
       end
 
+      define_loader :books, key: -> { id } do |keys, _subdeps|
+        books = Book.list(user_ids: keys).group_by(&:author_id)
+        keys.map { |key| books[key] || [] }
+      end
+
       delegate_dependency :name, to: :raw_user
 
       dependency :name
       computed def fancy_name
         "#{name}-san"
+      end
+
+      dependency :books
+      computed def book_count
+        books.size
       end
     end
   end
@@ -101,6 +135,15 @@ RSpec.describe ComputedModel do
     it "fetches fancy_name" do
       expect(users.size).to eq(3)
       expect(users.map { |u| u.fancy_name}).to contain_exactly("User One-san", "User Two-san", "User Four-san")
+    end
+  end
+
+  context "when fetched with book_count" do
+    let(:users) { self.class::Sandbox::User.list([1, 2, 3, 4], with: [:book_count]) }
+
+    it "fetches book_count" do
+      expect(users.size).to eq(3)
+      expect(users.map { |u| u.book_count }).to contain_exactly(0, 3, 1)
     end
   end
 end

--- a/spec/computed_model_spec.rb
+++ b/spec/computed_model_spec.rb
@@ -65,8 +65,7 @@ RSpec.describe ComputedModel do
       end
 
       define_loader :books, key: -> { id } do |keys, _subdeps|
-        books = Book.list(user_ids: keys).group_by(&:author_id)
-        keys.map { |key| books[key] || [] }
+        Book.list(user_ids: keys).group_by(&:author_id)
       end
 
       delegate_dependency :name, to: :raw_user
@@ -78,7 +77,7 @@ RSpec.describe ComputedModel do
 
       dependency :books
       computed def book_count
-        books.size
+        (books || []).size
       end
     end
   end


### PR DESCRIPTION
depends on #1 

I tried to modify the `define_loader` interface to be more concise, referring to [GraphQL's DataLoader](https://github.com/graphql/dataloader#batch-function)