### PR TITLE
Remove computed_model_error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 - Breaking changes
   - `include ComputedModel` is now `include ComputedModel::Model`.
+  - `computed_model_error` was removed.
 - Changed
   - Separate `ComputedModel::Model` from `ComputedModel` https://github.com/wantedly/computed_model/pull/17
+  - Remove `computed_model_error` https://github.com/wantedly/computed_model/pull/18
 - Misc
   - Collect coverage https://github.com/wantedly/computed_model/pull/12 https://github.com/wantedly/computed_model/pull/16
   - Refactor tests https://github.com/wantedly/computed_model/pull/10 https://github.com/wantedly/computed_model/pull/15

--- a/lib/computed_model/model.rb
+++ b/lib/computed_model/model.rb
@@ -21,7 +21,7 @@ require 'set'
 #   end
 module ComputedModel::Model
   # A set of class methods for {ComputedModel}. Automatically included to the
-  # singleton class when you include {ComputedModel}.
+  # singleton class when you include {ComputedModel::Model}.
   module ClassMethods
     # Declares the dependency of a computed attribute. See {#computed} too.
     #

--- a/lib/computed_model/model.rb
+++ b/lib/computed_model/model.rb
@@ -134,8 +134,7 @@ module ComputedModel::Model
     # `define_loader :foo do ... end` generates a reader `foo` and a writer `foo=`.
     # The writer is only meant to be used in the loader.
     #
-    # The responsibility of loader is to call `foo=` for all the given objects,
-    # or set `computed_model_error` otherwise.
+    # The responsibility of loader is to call `foo=` for all the given objects.
     #
     # @param meth_name [Symbol] the name of the loaded attribute.
     # @param key [Proc] The proc to collect keys.
@@ -241,7 +240,6 @@ module ComputedModel::Model
         else
           raise "No dependency info for #{self}##{dep_name}"
         end
-        objs.reject! { |obj| !obj.computed_model_error.nil? }
       end
 
       orig_objs
@@ -294,12 +292,6 @@ module ComputedModel::Model
       visited.add(meth_name)
     end
   end
-
-  # An error field to prevent {ComputedModel::ClassMethods#bulk_load_and_compute}
-  # from loading remaining attributes.
-  #
-  # @return [StandardError]
-  attr_accessor :computed_model_error
 
   def self.included(klass)
     super

--- a/spec/dependency_spec.rb
+++ b/spec/dependency_spec.rb
@@ -298,4 +298,32 @@ RSpec.describe ComputedModel do
       }.to raise_error("Invalid dependency: [:special1, :special2]")
     end
   end
+
+  describe "missing primary loader" do
+    let(:user_class) do
+      Class.new do
+        def self.name; "User"; end
+        def self.to_s; "User"; end
+
+        include ComputedModel::Model
+
+        attr_reader :id
+
+        def initialize(raw_user)
+          @id = raw_user.id
+          @raw_user = raw_user
+        end
+
+        def self.list(ids, with:)
+          bulk_load_and_compute(with, ids: ids)
+        end
+      end
+    end
+
+    it "raises an error" do
+      expect {
+        user_class.list(raw_user_ids, with: [])
+      }.to raise_error(ArgumentError, 'No primary loader defined')
+    end
+  end
 end


### PR DESCRIPTION
## Why

`computed_model_error` was introduced to drop missing records from the list when `define_primary_loader` didn't exist. Now that `define_primary_loader` exists, `computed_model_error` has no proper usage. We may want to add error handling support later, but for the time being it would be better to drop the incomplete functionality.

## What
