### PR TITLE
Refactor: extract DepGraph from Model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - Changed
   - Separate `ComputedModel::Model` from `ComputedModel` https://github.com/wantedly/computed_model/pull/17
   - Remove `computed_model_error` https://github.com/wantedly/computed_model/pull/18
+- Refactored
+  - Extract `DepGraph` from `Model` https://github.com/wantedly/computed_model/pull/19
 - Misc
   - Collect coverage https://github.com/wantedly/computed_model/pull/12 https://github.com/wantedly/computed_model/pull/16
   - Refactor tests https://github.com/wantedly/computed_model/pull/10 https://github.com/wantedly/computed_model/pull/15

--- a/lib/computed_model.rb
+++ b/lib/computed_model.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "computed_model/version"
+require "computed_model/dep_graph"
 require "computed_model/model"
 
 module ComputedModel

--- a/lib/computed_model/dep_graph.rb
+++ b/lib/computed_model/dep_graph.rb
@@ -1,0 +1,154 @@
+# frozen_string_literal: true
+
+require 'set'
+
+module ComputedModel
+  # A dependency graph representation used within ComputedModel::Model.
+  # Usually you don't need to use this class directly.
+  #
+  # @example
+  #   graph = ComputedModel::DepGraph.new
+  #   graph << ComputedModel::DepGraph::Node.new(:computed, :foo, { bar: [] })
+  #   graph << ComputedModel::DepGraph::Node.new(:loaded, :bar, {})
+  #   plan = graph.plan([:foo])
+  class DepGraph
+    def initialize
+      @nodes = {}
+    end
+
+    # Returns the node with the specified name.
+    #
+    # @param name [Symbol] the name of the node
+    # @return [Node, nil]
+    #
+    # @example
+    #   graph = ComputedModel::DepGraph.new
+    #   graph[:foo]
+    def [](name)
+      @nodes[name]
+    end
+
+    # Adds the new node.
+    #
+    # @param node [Node]
+    # @return [void]
+    # @raise [ArgumentError] when the node already exists
+    #
+    # @example
+    #   graph = ComputedModel::DepGraph.new
+    #   graph << ComputedModel::DepGraph::Node.new(:computed, :foo, {})
+    def <<(node)
+      raise ArgumentError, "Field already declared: #{node.name}" if @nodes.key?(node.name)
+
+      @nodes[node.name] = node
+    end
+
+    # Computes the plan for the given requirements.
+    #
+    # @param deps [Array] the list of required nodes. Each dependency can optionally include subdeps hashes.
+    # @return [ComputedModel::Plan]
+    #
+    # @example Plain dependencies
+    #   graph.plan([:field1, :field2])
+    #
+    # @example Dependencies with subdeps
+    #   graph.plan([:field1, field2: { optional_field: {} }])
+    def plan(deps)
+      normalized = ComputedModel.normalize_dependencies(deps)
+      load_order = []
+      subdeps_hash = {}
+      visiting = Set[]
+      visited = Set[]
+
+      @nodes.each_value do |node|
+        next unless node.type == :primary
+
+        load_order << node.name
+        visiting.add node.name
+        visited.add node.name
+        subdeps_hash[node.name] ||= []
+      end
+
+      raise "Multiple primary fields: #{load_order.inspect}" if load_order.size > 1
+
+      normalized.each do |name, subdeps|
+        plan_dfs(name, subdeps, load_order, subdeps_hash, visiting, visited)
+      end
+
+      ComputedModel::Plan.new(load_order, subdeps_hash)
+    end
+
+    # @param name [Symbol]
+    # @param subdeps [Array]
+    # @param load_order [Array<Symbol>]
+    # @param subdeps_hash [Hash{Symbol=>Array}]
+    # @param visiting [Set<Symbol>]
+    # @param visited [Set<Symbol>]
+    private def plan_dfs(name, subdeps, load_order, subdeps_hash, visiting, visited)
+      (subdeps_hash[name] ||= []).push(*subdeps)
+      return if visited.include?(name)
+      raise "Cyclic dependency for ##{name}" if visiting.include?(name)
+      raise "No dependency info for ##{name}" unless @nodes.key?(name)
+
+      visiting.add(name)
+
+      @nodes[name].edges.each_value do |edge|
+        plan_dfs(edge.name, edge.spec, load_order, subdeps_hash, visiting, visited)
+      end
+
+      load_order << name
+      visiting.delete(name)
+      visited.add(name)
+    end
+
+    # A node in the dependency graph. That is, a field in a computed model.
+    #
+    # @example computed node with plain dependencies
+    #   Node.new(:computed, :field1, { field2: [], field3: [] })
+    # @example computed node with subdeps
+    #   Node.new(:computed, :field1, { field2: [:foo, bar: []], field3: [] })
+    # @example loaded and primary dependencies
+    #   Node.new(:loaded, :field1, {})
+    #   Node.new(:primary, :field1, {})
+    class Node
+      # @return [Symbol] the type of the node. One of :computed, :loaded and :primary.
+      attr_reader :type
+      # @return [Symbol] the name of the node.
+      attr_reader :name
+      # @return [Hash{Symbol => Edge}] edges indexed by its name.
+      attr_reader :edges
+
+      ALLOWED_TYPES = %i[computed loaded primary].freeze
+      private_constant :ALLOWED_TYPES
+
+      # @param type [Symbol] the type of the node. One of :computed, :loaded and :primary.
+      # @param name [Symbol] the name of the node.
+      # @param edges [Array<(Symbol, Hash)>, Hash, Symbol] list of edges.
+      def initialize(type, name, edges)
+        raise ArgumentError, "invalid type: #{type.inspect}" unless ALLOWED_TYPES.include?(type)
+
+        edges = ComputedModel.normalize_dependencies(edges)
+        raise ArgumentError, "primary field cannot have dependency: #{name}" if type == :primary && edges.size > 0
+
+        @type = type
+        @name = name
+        @edges = edges.map { |k, v| [k, Edge.new(k, v)] }.to_h.freeze
+      end
+    end
+
+    # An edge in the dependency graph. That is, a dependency declaration in a computed model.
+    class Edge
+      # @return [Symbol] the name of the dependency (not the dependent)
+      attr_reader :name
+      # @return [Array] an auxiliary data called subdeps
+      attr_reader :spec
+
+      # @param name [Symbol] the name of the dependency (not the dependent)
+      # @param spec [Array] an auxiliary data called subdeps
+      def initialize(name, spec)
+        @name = name
+        @spec = Array(spec)
+      end
+    end
+  end
+end

--- a/lib/computed_model/model.rb
+++ b/lib/computed_model/model.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require "computed_model/version"
-require 'set'
-
 # A mixin for batch-loadable compound models.
 #
 # @example typical structure of a computed model
@@ -66,7 +63,7 @@ module ComputedModel::Model
       meth_name_orig = :"#{meth_name}_orig"
       compute_meth_name = :"compute_#{meth_name}"
 
-      @__computed_model_dependencies[meth_name] = ComputedModel.normalize_dependencies(@__computed_model_next_dependency)
+      @__computed_model_graph << ComputedModel::DepGraph::Node.new(:computed, meth_name, @__computed_model_next_dependency)
       remove_instance_variable(:@__computed_model_next_dependency)
 
       alias_method meth_name_orig, meth_name
@@ -154,6 +151,7 @@ module ComputedModel::Model
 
       var_name = :"@#{meth_name}"
 
+      @__computed_model_graph << ComputedModel::DepGraph::Node.new(:loaded, meth_name, {})
       @__computed_model_loaders[meth_name] = ComputedModel::Loader.new(key, block)
 
       define_method(meth_name) do
@@ -194,6 +192,7 @@ module ComputedModel::Model
 
       var_name = :"@#{meth_name}"
 
+      @__computed_model_graph << ComputedModel::DepGraph::Node.new(:primary, meth_name, {})
       @__computed_model_primary_loader = block
       @__computed_model_primary_attribute = meth_name
 
@@ -215,20 +214,17 @@ module ComputedModel::Model
       __cm_check_primary_loader
 
       objs = orig_objs = nil
-      plan = computing_plan(deps)
+      plan = @__computed_model_graph.plan(deps)
       plan.load_order.each do |dep_name|
-        if @__computed_model_primary_attribute == dep_name
+        case @__computed_model_graph[dep_name].type
+        when :primary
           orig_objs = @__computed_model_primary_loader.call(plan.subdeps_hash[dep_name], **options)
           objs = orig_objs.dup
-        elsif @__computed_model_dependencies.key?(dep_name)
-          raise "Bug: objs is nil" if objs.nil?
-
+        when :computed
           objs.each do |obj|
             obj.send(:"compute_#{dep_name}")
           end
-        elsif @__computed_model_loaders.key?(dep_name)
-          raise "Bug: objs is nil" if objs.nil?
-
+        when :loaded
           l = @__computed_model_loaders[dep_name]
           keys = objs.map { |o| o.instance_exec(&(l.key_proc)) }
           subobj_by_key = l.load_proc.call(keys, plan.subdeps_hash[dep_name], **options)
@@ -243,54 +239,6 @@ module ComputedModel::Model
       orig_objs
     end
 
-    # @param deps [Array]
-    # @return [ComputedModel::Plan]
-    def computing_plan(deps)
-      __cm_check_primary_loader
-      normalized = ComputedModel.normalize_dependencies(deps)
-      load_order = []
-      subdeps_hash = {}
-      visiting = Set[]
-      visited = Set[]
-
-      load_order << @__computed_model_primary_attribute
-      visiting.add @__computed_model_primary_attribute
-      visited.add @__computed_model_primary_attribute
-      subdeps_hash[@__computed_model_primary_attribute] ||= []
-
-      normalized.each do |dep_name, dep_subdeps|
-        computing_plan_dfs(dep_name, dep_subdeps, load_order, subdeps_hash, visiting, visited)
-      end
-
-      ComputedModel::Plan.new(load_order, subdeps_hash)
-    end
-
-    # @param meth_name [Symbol]
-    # @param meth_subdeps [Array]
-    # @param load_order [Array<Symbol>]
-    # @param subdeps_hash [Hash{Symbol=>Array}]
-    # @param visiting [Set<Symbol>]
-    # @param visited [Set<Symbol>]
-    private def computing_plan_dfs(meth_name, meth_subdeps, load_order, subdeps_hash, visiting, visited)
-      (subdeps_hash[meth_name] ||= []).push(*meth_subdeps)
-      return if visited.include?(meth_name)
-      raise "Cyclic dependency for #{self}##{meth_name}" if visiting.include?(meth_name)
-      visiting.add(meth_name)
-
-      if @__computed_model_dependencies.key?(meth_name)
-        @__computed_model_dependencies[meth_name].each do |dep_name, dep_subdeps|
-          computing_plan_dfs(dep_name, dep_subdeps, load_order, subdeps_hash, visiting, visited)
-        end
-      elsif @__computed_model_loaders.key?(meth_name)
-      else
-        raise "No dependency info for #{self}##{meth_name}"
-      end
-
-      load_order << meth_name
-      visiting.delete(meth_name)
-      visited.add(meth_name)
-    end
-
     private def __cm_check_primary_loader
       raise ArgumentError, 'No primary loader defined' unless @__computed_model_primary_attribute
     end
@@ -299,7 +247,7 @@ module ComputedModel::Model
   def self.included(klass)
     super
     klass.extend ClassMethods
-    klass.instance_variable_set(:@__computed_model_dependencies, {})
+    klass.instance_variable_set(:@__computed_model_graph, ComputedModel::DepGraph.new)
     klass.instance_variable_set(:@__computed_model_loaders, {})
     klass.instance_variable_set(:@__computed_model_primary_loader, nil)
     klass.instance_variable_set(:@__computed_model_primary_attribute, nil)

--- a/spec/dep_graph_spec.rb
+++ b/spec/dep_graph_spec.rb
@@ -1,0 +1,98 @@
+require 'spec_helper'
+
+RSpec.describe ComputedModel::DepGraph do
+  describe '<<' do
+    it 'raises an error on duplicate nodes' do
+      graph = ComputedModel::DepGraph.new
+      graph << ComputedModel::DepGraph::Node.new(:computed, :foo, {})
+      expect {
+        graph << ComputedModel::DepGraph::Node.new(:computed, :foo, {})
+      }.to raise_error(ArgumentError, 'Field already declared: foo')
+    end
+  end
+
+  describe '[]' do
+    it 'returns the added node' do
+      graph = ComputedModel::DepGraph.new
+      foo = ComputedModel::DepGraph::Node.new(:computed, :foo, {})
+      bar = ComputedModel::DepGraph::Node.new(:loaded, :bar, {})
+      graph << foo
+      graph << bar
+      expect(graph[:foo]).to be(foo)
+      expect(graph[:bar]).to be(bar)
+    end
+
+    it 'returns nil for unknown node name' do
+      graph = ComputedModel::DepGraph.new
+      foo = ComputedModel::DepGraph::Node.new(:computed, :foo, {})
+      bar = ComputedModel::DepGraph::Node.new(:loaded, :bar, {})
+      graph << foo
+      graph << bar
+      expect(graph[:baz]).to be_nil
+    end
+  end
+
+  describe '#plan' do
+    it 'returns a sorted plan' do
+      graph = ComputedModel::DepGraph.new
+      graph << ComputedModel::DepGraph::Node.new(:computed, :field1, { field2: {} })
+      graph << ComputedModel::DepGraph::Node.new(:loaded, :field2, {})
+      graph << ComputedModel::DepGraph::Node.new(:computed, :field3, { field2: {} })
+      graph << ComputedModel::DepGraph::Node.new(:primary, :field4, {})
+      plan = graph.plan([:field1, :field2, :field3])
+      expect(plan.load_order).to eq([:field4, :field2, :field1, :field3])
+    end
+
+    it 'returns a plan with only necessary fields' do
+      graph = ComputedModel::DepGraph.new
+      graph << ComputedModel::DepGraph::Node.new(:computed, :field1, { field2: {} })
+      graph << ComputedModel::DepGraph::Node.new(:loaded, :field2, {})
+      graph << ComputedModel::DepGraph::Node.new(:computed, :field3, { field2: {} })
+      graph << ComputedModel::DepGraph::Node.new(:primary, :field4, {})
+      plan = graph.plan([:field1])
+      expect(plan.load_order).to eq([:field4, :field2, :field1])
+    end
+
+    it 'collects subdeps_hash' do
+      graph = ComputedModel::DepGraph.new
+      graph << ComputedModel::DepGraph::Node.new(:computed, :field1, { field2: { a: 42 } })
+      graph << ComputedModel::DepGraph::Node.new(:loaded, :field2, {})
+      graph << ComputedModel::DepGraph::Node.new(:computed, :field3, { field2: { b: 84 } })
+      graph << ComputedModel::DepGraph::Node.new(:primary, :field4, {})
+      graph << ComputedModel::DepGraph::Node.new(:computed, :field5, { field2: { c: 420 } })
+      plan = graph.plan([:field1, :field5])
+      expect(plan.load_order).to eq([:field4, :field2, :field1, :field5])
+      expect(plan.subdeps_hash).to eq({
+                                        field1: [],
+                                        field2: [{ a: 42 }, { c: 420 }],
+                                        field4: [],
+                                        field5: []
+                                      })
+    end
+
+    it 'raises an error on multiple primary fields' do
+      graph = ComputedModel::DepGraph.new
+      graph << ComputedModel::DepGraph::Node.new(:primary, :field1, {})
+      graph << ComputedModel::DepGraph::Node.new(:primary, :field2, {})
+      expect {
+        graph.plan([])
+      }.to raise_error(RuntimeError, 'Multiple primary fields: [:field1, :field2]')
+    end
+  end
+
+  describe '::Node' do
+    describe '.new' do
+      it 'raises an error on invalid type' do
+        expect {
+          ComputedModel::DepGraph::Node.new(:something, :foo, {})
+        }.to raise_error(ArgumentError, 'invalid type: :something')
+      end
+
+      it 'raises an error on primary field with dependency' do
+        expect {
+          ComputedModel::DepGraph::Node.new(:primary, :foo, { bar: {} })
+        }.to raise_error(ArgumentError, 'primary field cannot have dependency: foo')
+      end
+    end
+  end
+end

--- a/spec/dependency_spec.rb
+++ b/spec/dependency_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe ComputedModel do
       it "raises an error" do
         expect {
           user_class.list(raw_user_ids, with: [:name])
-        }.to raise_error("Cyclic dependency for User#name")
+        }.to raise_error("Cyclic dependency for #name")
       end
     end
 
@@ -83,7 +83,7 @@ RSpec.describe ComputedModel do
       it "raises an error" do
         expect {
           user_class.list(raw_user_ids, with: [:name])
-        }.to raise_error("Cyclic dependency for User#name")
+        }.to raise_error("Cyclic dependency for #name")
       end
     end
 
@@ -114,7 +114,7 @@ RSpec.describe ComputedModel do
     it "raises an error" do
       expect {
         user_class.list(raw_user_ids, with: [:namae])
-      }.to raise_error("No dependency info for User#namae")
+      }.to raise_error("No dependency info for #namae")
     end
   end
 


### PR DESCRIPTION
## Why

So far, `ComputedModel::Model` managed all the dependency things. However, dependency graphs and their resolution can be separated from `ComputedModel::Model`.

## What

Extract `ComputedModel::DepGraph` from `ComputedModel::Model`. `ComputedModel::Model` concentrates more on programmer interfaces and managing class states.