### PR TITLE
Improve behavior around dependecy-field pairing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,12 @@
 - Breaking changes
   - `include ComputedModel` is now `include ComputedModel::Model`.
   - `computed_model_error` was removed.
+  - `dependency` before `define_loader` will be consumed and ignored.
+  - `dependency` before `define_primary_loader` will be an error.
 - Changed
   - Separate `ComputedModel::Model` from `ComputedModel` https://github.com/wantedly/computed_model/pull/17
   - Remove `computed_model_error` https://github.com/wantedly/computed_model/pull/18
+  - Improve behavior around dependency-field pairing https://github.com/wantedly/computed_model/pull/20
 - Refactored
   - Extract `DepGraph` from `Model` https://github.com/wantedly/computed_model/pull/19
 - Misc

--- a/lib/computed_model/model.rb
+++ b/lib/computed_model/model.rb
@@ -64,7 +64,7 @@ module ComputedModel::Model
       compute_meth_name = :"compute_#{meth_name}"
 
       @__computed_model_graph << ComputedModel::DepGraph::Node.new(:computed, meth_name, @__computed_model_next_dependency)
-      remove_instance_variable(:@__computed_model_next_dependency)
+      remove_instance_variable(:@__computed_model_next_dependency) if defined?(@__computed_model_next_dependency)
 
       alias_method meth_name_orig, meth_name
       define_method(meth_name) do
@@ -147,6 +147,7 @@ module ComputedModel::Model
     #     UserAuxData.where(user_id: user_ids).preload(subdeps).group_by(&:id)
     #   end
     def define_loader(meth_name, key:, &block)
+      remove_instance_variable(:@__computed_model_next_dependency) if defined?(@__computed_model_next_dependency)
       raise ArgumentError, "No block given" unless block
 
       var_name = :"@#{meth_name}"
@@ -187,6 +188,10 @@ module ComputedModel::Model
     #     end
     #   end
     def define_primary_loader(meth_name, &block)
+      if defined?(@__computed_model_next_dependency)
+        remove_instance_variable(:@__computed_model_next_dependency)
+        raise ArgumentError, 'primary field cannot have a dependency'
+      end
       raise ArgumentError, "No block given" unless block
       raise ArgumentError, "Primary loader has already been defined" if @__computed_model_primary_attribute
 


### PR DESCRIPTION
## Why

The `dependency` method is stateful; for example, the following code snippet is totally valid.

```ruby
dependency :foo
# ... doing something ...
computed def bar; ...; end
```

Of course, you should avoid such code for clarity. Among these confusing uses, the following is forward-incompatible:

```ruby
dependency :foo
define_loader :bar, key: -> { id } do ... end

dependency :bar
computed def baz; ...; end
```

The current version of computed_model misinterprets it as the following:

```ruby
define_loader :bar, key: -> { id } do ... end

dependency :foo, :bar
computed def baz; ...; end
```

which is not something we intend to.

## What

Change how we consume `dependency` for the sake of forward compatibility. That is, all of `computed def`, `define_loader`, `define_primary_loader` consumes the state generated by `dependency`. Note the following:

- `define_loader` ignores the dependency for now. It might be implemented in future versions.
- `define_primary_loader` cannot accept dependency by its nature. So it will be an error to declare `dependency` before `define_primary_loader`.