### PR TITLE
Refactor: define loader as a singleton method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
   - Improve behavior around dependency-field pairing https://github.com/wantedly/computed_model/pull/20
 - Refactored
   - Extract `DepGraph` from `Model` https://github.com/wantedly/computed_model/pull/19
+  - Define loader as a singleton method https://github.com/wantedly/computed_model/pull/21
 - Misc
   - Collect coverage https://github.com/wantedly/computed_model/pull/12 https://github.com/wantedly/computed_model/pull/16
   - Refactor tests https://github.com/wantedly/computed_model/pull/10 https://github.com/wantedly/computed_model/pull/15

--- a/lib/computed_model/dep_graph.rb
+++ b/lib/computed_model/dep_graph.rb
@@ -69,6 +69,7 @@ module ComputedModel
         subdeps_hash[node.name] ||= []
       end
 
+      raise ArgumentError, 'No primary loader defined' if load_order.empty?
       raise "Multiple primary fields: #{load_order.inspect}" if load_order.size > 1
 
       normalized.each do |name, subdeps|


### PR DESCRIPTION
## Why

To support inheritance & mixin in the future, and just as a refactoring

## What

Define a loader or a primary loader as a singleton method.