### PR TITLE
Implement strict field access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Breaking changes
   - `include ComputedModel` is now `include ComputedModel::Model`.
+  - Indirect dependencies are now rejected.
   - `computed_model_error` was removed.
   - `dependency` before `define_loader` will be consumed and ignored.
   - `dependency` before `define_primary_loader` will be an error.
@@ -9,6 +10,7 @@
   - Separate `ComputedModel::Model` from `ComputedModel` https://github.com/wantedly/computed_model/pull/17
   - Remove `computed_model_error` https://github.com/wantedly/computed_model/pull/18
   - Improve behavior around dependency-field pairing https://github.com/wantedly/computed_model/pull/20
+  - Implement strict field access https://github.com/wantedly/computed_model/pull/23
 - Refactored
   - Extract `DepGraph` from `Model` https://github.com/wantedly/computed_model/pull/19
   - Define loader as a singleton method https://github.com/wantedly/computed_model/pull/21

--- a/lib/computed_model.rb
+++ b/lib/computed_model.rb
@@ -10,6 +10,10 @@ module ComputedModel
   # but that attribute isn't loaded by the batch loader.
   class NotLoaded < StandardError; end
 
+  # An error raised when you tried to read from a loaded/computed attribute,
+  # but that attribute isn't listed in the dependencies list.
+  class ForbiddenDependency < StandardError; end
+
   # @param deps [Array<(Symbol, Hash)>, Hash, Symbol]
   # @return [Hash{Symbol=>Array}]
   def self.normalize_dependencies(deps)

--- a/lib/computed_model/plan.rb
+++ b/lib/computed_model/plan.rb
@@ -14,7 +14,14 @@ module ComputedModel
     # @param toplevel [Set<Symbol>] toplevel dependencies
     def initialize(load_order, toplevel)
       @load_order = load_order.freeze
+      @nodes = load_order.map { |node| [node.name, node] }.to_h
       @toplevel = toplevel
+    end
+
+    # @param name [Symbol]
+    # @return [ComputedModel::Plan::Node, nil]
+    def [](name)
+      @nodes[name]
     end
 
     # A set of information necessary to invoke the loader or the computed def.

--- a/spec/computed_model_spec.rb
+++ b/spec/computed_model_spec.rb
@@ -92,9 +92,11 @@ RSpec.describe ComputedModel do
 
   context "when fetched with name" do
     let(:users) { self.class::Sandbox::User.list(raw_user_ids, with: [:name]) }
-    it "fetches raw_user.name" do
+    it "doesn't allow accessing raw_user.name" do
       expect(users.size).to eq(3)
-      expect(users.map { |u| u.raw_user.name}).to contain_exactly("User One", "User Two", "User Four")
+      expect {
+        users[0].raw_user
+      }.to raise_error(ComputedModel::ForbiddenDependency, 'Not a direct dependency: raw_user')
     end
 
     it "fetches name" do
@@ -111,14 +113,18 @@ RSpec.describe ComputedModel do
 
   context "when fetched with fancy_name" do
     let(:users) { self.class::Sandbox::User.list(raw_user_ids, with: [:fancy_name]) }
-    it "fetches raw_user.name" do
+    it "doesn't allow accessing raw_user.name" do
       expect(users.size).to eq(3)
-      expect(users.map { |u| u.raw_user.name}).to contain_exactly("User One", "User Two", "User Four")
+      expect {
+        users[0].raw_user
+      }.to raise_error(ComputedModel::ForbiddenDependency, 'Not a direct dependency: raw_user')
     end
 
-    it "fetches name" do
+    it "doesn't allow accessing name" do
       expect(users.size).to eq(3)
-      expect(users.map { |u| u.name}).to contain_exactly("User One", "User Two", "User Four")
+      expect {
+        users[0].name
+      }.to raise_error(ComputedModel::ForbiddenDependency, 'Not a direct dependency: name')
     end
 
     it "fetches fancy_name" do


### PR DESCRIPTION
## Why

In the present computed_model implementation, one can access a field not listed as a direct dependency:

```ruby
class User
  dependency :name
  computed def fancy_name
  end
end

user = User.get(id, with: [:fancy_name])
user.name  # allowed
```

```ruby
class Foo
  dependency :field1
  computed def field2
  end

  dependency :field2
  computed def field3
    field1  # allowed
  end
end
```

However, this is prone to mistakes in future changes. We'd like to forbid such uses in the first place.

## What

Implement strict field access. From now on, only direct dependencies can be accessed. This is controlled by an internal state `@__computed_model_stack` in each model object.
