### PR TITLE
Implement conditional dependencies and subdependency mapping/passthrough

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
   - `dependency` before `define_loader` will be consumed and ignored.
   - `dependency` before `define_primary_loader` will be an error.
   - Cyclic dependency is an error even if it is unused.
+  - `nil`, `true`, and `false` in subdeps will be filtered out before passed to a loader.
+  - `ComputedModel.normalized_dependencies` now returns `[true]` instead of `[]` as an empty value.
 - Notable behavioral changes
   - The order in which fields are loaded is changed.
 - Changed
@@ -15,6 +17,7 @@
   - Improve behavior around dependency-field pairing https://github.com/wantedly/computed_model/pull/20
   - Implement strict field access https://github.com/wantedly/computed_model/pull/23
   - Preprocess graph with topological sorting https://github.com/wantedly/computed_model/pull/24
+  - Implement conditional dependencies and subdependency mapping/passthrough https://github.com/wantedly/computed_model/pull/25
 - Added
   - `ComputedModel::Model#verify_dependencies`
 - Refactored

--- a/lib/computed_model.rb
+++ b/lib/computed_model.rb
@@ -24,16 +24,31 @@ module ComputedModel
     Array(deps).each do |elem|
       case elem
       when Symbol
-        normalized[elem] ||= []
+        normalized[elem] ||= [true]
       when Hash
         elem.each do |k, v|
           v = [v] if v.is_a?(Hash)
           normalized[k] ||= []
           normalized[k].push(*Array(v))
+          normalized[k].push(true) if v == []
         end
       else; raise "Invalid dependency: #{elem.inspect}"
       end
     end
     normalized
+  end
+
+  # @param subdeps [Array]
+  # @return [Array]
+  def self.filter_subdeps(subdeps)
+    subdeps.select { |x| x && x != true }
+  end
+
+  # Convenience class to easily access normalized version of dependencies.
+  class NormalizableArray < Array
+    # @return [Hash{Symbol=>Array}]
+    def normalized
+      @normalized ||= ComputedModel.normalize_dependencies(ComputedModel.filter_subdeps(self))
+    end
   end
 end

--- a/lib/computed_model/dep_graph.rb
+++ b/lib/computed_model/dep_graph.rb
@@ -135,7 +135,7 @@ module ComputedModel
       attr_reader :spec
 
       # @param name [Symbol] the name of the dependency (not the dependent)
-      # @param spec [Array, Proc] an auxiliary data called subdeps
+      # @param spec [Array] an auxiliary data called subdeps
       def initialize(name, spec)
         @name = name
         @spec = Array(spec)

--- a/lib/computed_model/plan.rb
+++ b/lib/computed_model/plan.rb
@@ -30,12 +30,12 @@ module ComputedModel
       attr_reader :name
       # @return [Set<Symbol>] set of dependency names
       attr_reader :deps
-      # @return [Array] a payload given to the loader
+      # @return [ComputedModel::NormalizableArray] a payload given to the loader
       attr_reader :subdeps
 
       # @param name [Symbol] field name
       # @param deps [Set<Symbol>] set of dependency names
-      # @param subdeps [Array] a payload given to the loader
+      # @param subdeps [ComputedModel::NormalizableArray] a payload given to the loader
       def initialize(name, deps, subdeps)
         @name = name
         @deps = deps

--- a/spec/dep_graph_spec.rb
+++ b/spec/dep_graph_spec.rb
@@ -65,8 +65,8 @@ RSpec.describe ComputedModel::DepGraph do
       subdeps_expect = {
         field4: [],
         field2: [{ a: 42 }, { c: 420 }],
-        field1: [],
-        field5: []
+        field1: [true],
+        field5: [true]
       }
       expect(plan.load_order.map { |n| [n.name, n.subdeps] }.to_h).to eq(subdeps_expect)
     end


### PR DESCRIPTION
## Why

This is a PR for the long-awaited features: **conditional dependencies** and **subdependency mapping/passthrough**. In short, computed fields can now accept subdeps.

### conditional dependencies

Load `foo` only when `use_foo` is specified.

```ruby
dependency foo: -> (subdeps) { subdeps.normalized[:use_foo].any? }
computed def bar; end
```

### subdependency mapping

Load `foo` with subdeps specified in `foospec`.

```ruby
dependency foo: -> (subdeps) { subdeps.normalized[:foospec] }
computed def bar; end
```

### subdependency passthrough

Delegate subdeps as-is.

```ruby
dependency foo: -> (subdeps) { subdeps }
computed def bar; end
```

## What

To support conditional dependencies, the following changes are made to the interpretation of subdeps:

- A callable object will be evaluated if it's in a field's dependency list. If it returns an array, it's flattened.
- subdeps must have at least one truthy value. Otherwise the dependency is considered disabled.

To maintain compatibility and intuition, the normalization process is also changed:

- `:foo` or `[:foo]` will be normalized into `{ foo: [true] }` (previously `{ foo: [] }`).
- `{ foo: [] }` will be normalized into `{ foo: [true] }` (previously `{ foo: [] }`).

The values `nil`, `false`, `true` are filtered out in the following cases:

- Before passed to a loader (defined by `define_loader` or `define_primary_loader`).
- Before normalization in `-> (subdeps) { subdeps.normalized ... }`. Note that the `subdeps` parameter itself keeps these values as-is.