### PR TITLE
Use ActiveSupport::Concern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
   - `ComputedModel.normalized_dependencies` now returns `[true]` instead of `[]` as an empty value.
 - Notable behavioral changes
   - The order in which fields are loaded is changed.
+  - `ComputedModel::Model` now uses `ActiveSupport::Concern`.
 - Changed
   - Separate `ComputedModel::Model` from `ComputedModel` https://github.com/wantedly/computed_model/pull/17
   - Remove `computed_model_error` https://github.com/wantedly/computed_model/pull/18
@@ -18,6 +19,7 @@
   - Implement strict field access https://github.com/wantedly/computed_model/pull/23
   - Preprocess graph with topological sorting https://github.com/wantedly/computed_model/pull/24
   - Implement conditional dependencies and subdependency mapping/passthrough https://github.com/wantedly/computed_model/pull/25
+  - Use `ActiveSupport::Concern` https://github.com/wantedly/computed_model/pull/26
 - Added
   - `ComputedModel::Model#verify_dependencies`
 - Refactored

--- a/computed_model.gemspec
+++ b/computed_model.gemspec
@@ -35,6 +35,9 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  # For ActiveSupport::Concern
+  spec.add_development_dependency "activesupport"
+
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.0"

--- a/lib/computed_model/model.rb
+++ b/lib/computed_model/model.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'active_support/concern'
+
 # A mixin for batch-loadable compound models.
 #
 # @example typical structure of a computed model
@@ -17,6 +19,8 @@
 #     computed def something ... end
 #   end
 module ComputedModel::Model
+  extend ActiveSupport::Concern
+
   # A set of class methods for {ComputedModel}. Automatically included to the
   # singleton class when you include {ComputedModel::Model}.
   module ClassMethods
@@ -295,10 +299,8 @@ module ComputedModel::Model
     raise ComputedModel::ForbiddenDependency, "Not a direct dependency: #{name}"
   end
 
-  def self.included(klass)
-    super
-    klass.extend ClassMethods
-    klass.instance_variable_set(:@__computed_model_graph, ComputedModel::DepGraph.new)
-    klass.instance_variable_set(:@__computed_model_sorted_graph, nil)
+  included do
+    @__computed_model_graph = ComputedModel::DepGraph.new
+    @__computed_model_sorted_graph = nil
   end
 end


### PR DESCRIPTION
## Why

There are a bunch of pitfalls when writing mixins, and we don't want to re-iterate them ourselves.

## What

Use `ActiveSupport::Concern`.