### PR TITLE
Support computed model inheritance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Added
   - `ComputedModel::Model#verify_dependencies`
   - Loader dependency https://github.com/wantedly/computed_model/pull/28
+  - Support computed model inheritance https://github.com/wantedly/computed_model/pull/29
 - Refactored
   - Extract `DepGraph` from `Model` https://github.com/wantedly/computed_model/pull/19
   - Define loader as a singleton method https://github.com/wantedly/computed_model/pull/21

--- a/spec/inheritance_spec.rb
+++ b/spec/inheritance_spec.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'support/models/raw_user'
+require 'support/models/raw_book'
+
+RSpec.describe ComputedModel::Model do
+  describe "simple inheritance" do
+    it "mixes inherited fields" do
+      base_klass = Class.new do
+        include ComputedModel::Model
+
+        attr_reader :id
+        def initialize(id)
+          @id = id
+        end
+
+        define_loader :field1, key: -> { id } do
+          { 1 => 'foo', 2 => 'bar' }
+        end
+
+        def field2; raise NotImplementedError; end
+
+        dependency :field2
+        computed def field3
+          "#{field2}-chocolate"
+        end
+      end
+
+      subklass = Class.new(base_klass) do
+        define_primary_loader :primary do
+          [new(1), new(2)]
+        end
+
+        dependency :field1
+        computed def field2
+          "#{field1}-strawberry"
+        end
+
+        dependency :field3
+        computed def field4
+          "#{field3}-vanilla"
+        end
+      end
+
+      objs = subklass.bulk_load_and_compute([:field4])
+      expect(objs.map(&:field4)).to eq(['foo-strawberry-chocolate-vanilla', 'bar-strawberry-chocolate-vanilla'])
+    end
+  end
+
+  describe "missing inclusion" do
+    it "errors on missing inclusion in the indirectly included module" do
+      indirect_module = Module.new do
+        include ComputedModel::Model
+      end
+
+      expect {
+        Class.new do
+          include indirect_module
+
+          computed def foo
+            "foo"
+          end
+        end
+      }.to raise_error(NoMethodError, /^undefined method `computed' for #<Class:.*>$/)
+    end
+
+    it 'allows redirecting helper methods via ActiveSupport::Concern' do
+      indirect_module = Module.new do
+        extend ActiveSupport::Concern
+        include ComputedModel::Model
+      end
+
+      expect {
+        Class.new do
+          include indirect_module
+
+          computed def foo
+            "foo"
+          end
+        end
+      }.not_to raise_error
+    end
+  end
+
+  describe "invalid merger" do
+    it "errors on multiple types on the same field" do
+      base_klass = Class.new do
+        include ComputedModel::Model
+
+        attr_reader :id
+        def initialize(id)
+          @id = id
+        end
+
+        computed def field1; end
+      end
+
+      subklass = Class.new(base_klass) do
+        define_primary_loader :primary do
+          [new(1), new(2)]
+        end
+
+        define_loader :field1, key: -> { id } do
+          { 1 => 'foo', 2 => 'bar' }
+        end
+      end
+
+      expect {
+        subklass.bulk_load_and_compute([])
+      }.to raise_error(ArgumentError, 'Field field1 has multiple different types')
+    end
+  end
+end


### PR DESCRIPTION
## Why

Previously computed_model is not compatible with inheritance and mixin -- the important abstraction method in Ruby.

## What

Implement computed model inheritance. This is done in the following way:

- Each class/module have its own **partial graph** in `@__computed_model_graph`.
  - This partial graph need not have the primary loader or have all fields declared as dependencies.
- When doing topological sorting, all partial graphs from ancestors are combined into one graph.

Known problems:

- Once the topological sorting is calculated, no later addition of fields are taken into account. Note that this problem already exists in single-class cases.
- Computed field overriding may not work correctly, especially if `super` is used.