### PR TITLE
Rename subdeps as subfields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,13 +43,14 @@ See [Migration-0.3.md](Migration-0.3.md) for migration.
 Previously, subdeps are only useful for loaded fields and primary fields. Now computed fields can make use of subdeps!
 
 ```ruby
+
 class User
   # Delegate subdeps
   dependency(
     blog_articles: -> (subdeps) { subdeps }
   )
   computed def filtered_blog_articles
-    if current_subdeps.normalized[:image].any?
+    if current_subfields.normalized[:image].any?
       # ...
     end
     # ...

--- a/Migration-0.3.md
+++ b/Migration-0.3.md
@@ -126,6 +126,28 @@ However, in computed_model 0.3,
 it always leads to `ComputedModel::ForbiddenDependency`.
 
 
+## Major breaking: `subdeps` are now called `subfields`
+
+Before:
+
+```ruby
+class User
+  delegate_dependency :name, to: :raw_user, include_subdeps: true
+end
+```
+
+After:
+
+```ruby
+class User
+  delegate_dependency :name, to: :raw_user, include_subfields: true
+end
+```
+
+We also recommend renaming block parameters named `subdeps` as `subfields`,
+although not strictly necessary.
+
+
 ## Minor breaking: `computed_model_error` has been removed
 
 It was useful in computed_model 0.1 but no longer needed in computed_model 0.2.

--- a/README.ja.md
+++ b/README.ja.md
@@ -95,7 +95,7 @@ class User
     bulk_load_and_compute(Array(with), ids: ids)
   end
 
-  define_primary_loader :raw_user do |_subdeps, ids:, **|
+  define_primary_loader :raw_user do |_subfields, ids:, **|
     # ActiveRecordの場合:
     # raw_users = RawUser.where(id: ids).to_a
     raw_users = [
@@ -105,7 +105,7 @@ class User
     raw_users.map { |u| User.new(u) }
   end
 
-  define_loader :preference, key: -> { id } do |user_ids, _subdeps, **|
+  define_loader :preference, key: -> { id } do |user_ids, _subfields, **|
     # ActiveRecordの場合:
     # Preference.where(user_id: user_ids).index_by(&:user_id)
     {

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ class User
     bulk_load_and_compute(Array(with), ids: ids)
   end
 
-  define_primary_loader :raw_user do |_subdeps, ids:, **|
+  define_primary_loader :raw_user do |_subfields, ids:, **|
     # In ActiveRecord:
     # raw_users = RawUser.where(id: ids).to_a
     raw_users = [
@@ -107,7 +107,7 @@ class User
     raw_users.map { |u| User.new(u) }
   end
 
-  define_loader :preference, key: -> { id } do |user_ids, _subdeps, **|
+  define_loader :preference, key: -> { id } do |user_ids, _subfields, **|
     # In ActiveRecord:
     # Preference.where(user_id: user_ids).index_by(&:user_id)
     {

--- a/lib/computed_model.rb
+++ b/lib/computed_model.rb
@@ -46,7 +46,7 @@ module ComputedModel
   #   # => { foo: [true], bar: [true, :baz] }
   #
   # @example
-  #   ComputedModel.normalize_dependencies(foo: -> (subdeps) { true })
+  #   ComputedModel.normalize_dependencies(foo: -> (subfields) { true })
   #   # => { foo: [#<Proc:...>] }
   def self.normalize_dependencies(deps)
     normalized = {}
@@ -75,20 +75,20 @@ module ComputedModel
   # {ComputedModel::Model::ClassMethods#define_primary_loader}, and
   # {ComputedModel::NormalizableArray#normalized} will internally use this function.
   #
-  # @param subdeps [Array] subfield selector list
+  # @param subfields [Array] subfield selector list
   # @return [Array] the filtered one
   # @example
-  #   ComputedModel.filter_subdeps([false, {}, true, nil, { foo: :bar }])
+  #   ComputedModel.filter_subfields([false, {}, true, nil, { foo: :bar }])
   #   # => [{}, { foo: :bar }]
-  def self.filter_subdeps(subdeps)
-    subdeps.select { |x| x && x != true }
+  def self.filter_subfields(subfields)
+    subfields.select { |x| x && x != true }
   end
 
   # Convenience class to easily access normalized version of dependencies.
   #
   # You don't need to directly use it.
   #
-  # - {ComputedModel::Model#current_subdeps} returns NormalizableArray.
+  # - {ComputedModel::Model#current_subfields} returns NormalizableArray.
   # - Procs passed to {ComputedModel::Model::ClassMethods#dependency} will receive NormalizeArray.
   class NormalizableArray < Array
     # Returns the normalized hash of the dependencies.
@@ -96,7 +96,7 @@ module ComputedModel
     # @raise [RuntimeError] if the list isn't valid as a dependency list.
     #   See {ComputedModel.normalize_dependencies} for details.
     def normalized
-      @normalized ||= ComputedModel.normalize_dependencies(ComputedModel.filter_subdeps(self))
+      @normalized ||= ComputedModel.normalize_dependencies(ComputedModel.filter_subfields(self))
     end
   end
 end

--- a/lib/computed_model/plan.rb
+++ b/lib/computed_model/plan.rb
@@ -32,16 +32,16 @@ module ComputedModel
       attr_reader :name
       # @return [Set<Symbol>] set of dependency names
       attr_reader :deps
-      # @return [ComputedModel::NormalizableArray] a payload given to the loader
-      attr_reader :subdeps
+      # @return [ComputedModel::NormalizableArray] subfield selectors, payloads sent to the dependency
+      attr_reader :subfields
 
       # @param name [Symbol] field name
       # @param deps [Set<Symbol>] set of dependency names
-      # @param subdeps [ComputedModel::NormalizableArray] a payload given to the loader
-      def initialize(name, deps, subdeps)
+      # @param subfields [ComputedModel::NormalizableArray] subfield selectors, payloads sent to the dependency
+      def initialize(name, deps, subfields)
         @name = name
         @deps = deps
-        @subdeps = subdeps
+        @subfields = subfields
       end
     end
   end

--- a/spec/computed_model_spec.rb
+++ b/spec/computed_model_spec.rb
@@ -32,12 +32,12 @@ RSpec.describe ComputedModel do
         bulk_load_and_compute(with, ids: ids)
       end
 
-      define_primary_loader :raw_user do |_subdeps, ids:, **_options|
+      define_primary_loader :raw_user do |_subfields, ids:, **_options|
         RawUser.where(id: ids).map { |raw_user| User.new(raw_user) }
       end
 
-      define_loader :books, key: -> { id } do |keys, subdeps|
-        Book.list(user_ids: keys, with: subdeps).group_by(&:author_id)
+      define_loader :books, key: -> { id } do |keys, subfields|
+        Book.list(user_ids: keys, with: subfields).group_by(&:author_id)
       end
 
       delegate_dependency :name, to: :raw_user
@@ -68,7 +68,7 @@ RSpec.describe ComputedModel do
         bulk_load_and_compute(with, user_ids: user_ids)
       end
 
-      define_primary_loader :raw_book do |_subdeps, user_ids:, **_options|
+      define_primary_loader :raw_book do |_subfields, user_ids:, **_options|
         RawBook.where(author_id: user_ids).map { |raw_book| Book.new(raw_book) }
       end
 

--- a/spec/dep_graph_spec.rb
+++ b/spec/dep_graph_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe ComputedModel::DepGraph do
       expect(plan.load_order.map(&:name)).to eq([:field4, :field2, :field1])
     end
 
-    it 'collects subdeps_hash' do
+    it 'collects the hash of subfield selectors' do
       graph = ComputedModel::DepGraph.new
       graph << ComputedModel::DepGraph::Node.new(:computed, :field1, { field2: { a: 42 } })
       graph << ComputedModel::DepGraph::Node.new(:loaded, :field2, {})
@@ -62,13 +62,13 @@ RSpec.describe ComputedModel::DepGraph do
       graph << ComputedModel::DepGraph::Node.new(:computed, :field5, { field2: { c: 420 } })
       plan = graph.tsort.plan([:field1, :field5])
       expect(plan.load_order.map(&:name)).to eq([:field4, :field2, :field1, :field5])
-      subdeps_expect = {
+      subfields_expect = {
         field4: [],
         field2: [{ a: 42 }, { c: 420 }],
         field1: [true],
         field5: [true]
       }
-      expect(plan.load_order.map { |n| [n.name, n.subdeps] }.to_h).to eq(subdeps_expect)
+      expect(plan.load_order.map { |n| [n.name, n.subfields] }.to_h).to eq(subfields_expect)
     end
 
     it 'collects deps' do

--- a/spec/utility_spec.rb
+++ b/spec/utility_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe ComputedModel::Model do
   let(:raw_user_ids) { [raw_user1.id, raw_user2.id] }
 
   let(:user_class) do
-    record_user_subdeps = -> (subdeps) { @user_subdeps = subdeps }
-    record_user_extra_subdeps = -> (subdeps) { @user_extra_subdeps = subdeps }
+    record_user_subfields = -> (subfields) { @user_subfields = subfields }
+    record_user_extra_subfields = -> (subfields) { @user_extra_subfields = subfields }
     Class.new do
       def self.name; 'User'; end
       def self.to_s; 'User'; end
@@ -31,13 +31,13 @@ RSpec.describe ComputedModel::Model do
         bulk_load_and_compute(with, ids: ids)
       end
 
-      define_primary_loader :raw_user do |subdeps, ids:, **_options|
-        record_user_subdeps.call(subdeps)
+      define_primary_loader :raw_user do |subfields, ids:, **_options|
+        record_user_subfields.call(subfields)
         RawUser.where(id: ids).map { |raw_user| self.new(raw_user) }
       end
 
-      define_loader :raw_user_extra, key: -> { id } do |keys, subdeps|
-        record_user_extra_subdeps.call(subdeps)
+      define_loader :raw_user_extra, key: -> { id } do |keys, subfields|
+        record_user_extra_subfields.call(subfields)
         RawUserExtra.where(id: keys).index_by(&:id)
       end
     end
@@ -98,29 +98,29 @@ RSpec.describe ComputedModel::Model do
       end
     end
 
-    describe 'without include_subdeps' do
+    describe 'without include_subfields' do
       before do
         user_class.module_eval do
           delegate_dependency :name, to: :raw_user
         end
       end
 
-      it "doesn't generate subdeps" do
+      it "doesn't generate subfields" do
         User.list(raw_user_ids, with: [:name])
-        expect(@user_subdeps).to eq([])
+        expect(@user_subfields).to eq([])
       end
     end
 
-    describe 'without include_subdeps' do
+    describe 'without include_subfields' do
       before do
         user_class.module_eval do
-          delegate_dependency :name, to: :raw_user, include_subdeps: true
+          delegate_dependency :name, to: :raw_user, include_subfields: true
         end
       end
 
-      it 'generates subdeps' do
+      it 'generates subfields' do
         User.list(raw_user_ids, with: [:name])
-        expect(@user_subdeps).to eq([:name])
+        expect(@user_subfields).to eq([:name])
       end
     end
   end


### PR DESCRIPTION
## Why

The name "subdependency" is inconvenient in the following senses:

- It doesn't distinguish nodes from edges in the dependency graph.
- Both "subdependency" and "subdeps" tend to be marked as a misspelling.

To aid this we introduce a different name for the notion: **subfields** and **subfield selectors**.

## What

Rename them all over the place. The only breaking change (compared to computed_model 0.2) is the following:

- `ComputedModel::Model#delegate_dependency` now accepts `include_subfields` other than `include_subdeps`.